### PR TITLE
Chore: Styling Enhancements

### DIFF
--- a/src/app/(site)/account/_components/account-sections.tsx
+++ b/src/app/(site)/account/_components/account-sections.tsx
@@ -3,16 +3,41 @@
 import { useIsMounted } from '~/hooks/use-is-mounted';
 import { AccountProfile } from './account-profile';
 import { SubscriptionBilling } from './subscription-billing';
+import Button from '~/components/Button';
+import { useRouter } from 'next/navigation';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+import toast from 'react-hot-toast';
+import Link from 'next/link';
 
 export function AccountSections() {
   const isMounted = useIsMounted();
 
   if (!isMounted) return null;
 
+  const router = useRouter();
+
+  const supabaseClient = useSupabaseClient();
+
+  const handleLogout = async () => {
+    const { error } = await supabaseClient.auth.signOut();
+    // TODO: reset any playing songs
+    router.refresh();
+
+    if (error) {
+      toast.error(error.message);
+    } else {
+      toast.success('Logged out successfully');
+    }
+  };
+
   return (
     <div className="p-6 space-y-9">
       <AccountProfile />
       <SubscriptionBilling />
+      <Link href="/"
+            onClick={handleLogout} className="inline-block px-6 py-2 bg-white text-black rounded-full">
+        Logout
+      </Link>
     </div>
   );
 }

--- a/src/app/(site)/album/[albumId]/_components/album-image.tsx
+++ b/src/app/(site)/album/[albumId]/_components/album-image.tsx
@@ -12,7 +12,7 @@ export function AlbumImage({ album }: AlbumImageProps) {
   const imageUrl = useLoadImage(album);
 
   return (
-    <div className="relative w-32 h-32 lg:h-44 lg:w-44">
+    <div className="relative aspect-square w-32 h-32 min-w-44 min-h-44 lg:w-44 lg:h-44">
       <Image
         fill
         alt="Album"

--- a/src/app/(site)/album/[albumId]/page.tsx
+++ b/src/app/(site)/album/[albumId]/page.tsx
@@ -37,24 +37,21 @@ function AlbumHeader({ album }: { album: Album }) {
         <AlbumImage album={album} />
         <div className="flex flex-col mt-4 gap-y-2 md:mt-0">
           <p className="hidden text-sm font-semibold md:block">Album</p>
-          <h1 className="text-4xl font-bold text-white sm:text-5xl lg:text-7xl">
+          <h1 className="text-4xl font-bold text-white sm:text-5xl lg:text-6xl">
             {album?.name}
           </h1>
-          <span className="text-sm text-gray-300">
-            {album.author} &middot; {releaseDate} &middot;{' '}
-            <AlbumSongCount songs_count={album.songs_count} />,{' '}
-            {album.readable_duration}
-          </span>
+          <div className="text-sm text-gray-300 flex flex-col md:flex-row md:gap-x-2">
+            <span>{album.author}</span>
+            <span className="hidden md:inline">&middot;</span>
+            <span>{releaseDate}</span>
+            <span className="hidden md:inline">&middot;</span>
+            <span>
+              {album.songs_count} {album.songs_count === 1 ? 'song' : 'songs'},{' '}
+              {album.readable_duration}
+            </span>
+          </div>
         </div>
       </div>
     </Header>
   );
-}
-
-function AlbumSongCount({ songs_count }: { songs_count: number }) {
-  if (songs_count === 1) {
-    return <span>1 song</span>;
-  }
-
-  return <span>{songs_count} songs</span>;
 }

--- a/src/app/(site)/liked/_components/LikedContent.tsx
+++ b/src/app/(site)/liked/_components/LikedContent.tsx
@@ -29,7 +29,7 @@ const LikedContent: React.FC<LikedContentProps> = ({ songs: likedSongs }) => {
 
   if (songs.length === 0) {
     return (
-      <div className="flex flex-col w-full px-6 gap-y-2 text-neutral-400">
+      <div className="flex flex-col w-full px-6 text-center gap-y-2 text-neutral-400">
         No liked songs.
       </div>
     );

--- a/src/app/(site)/search/_components/SearchContent.tsx
+++ b/src/app/(site)/search/_components/SearchContent.tsx
@@ -10,7 +10,7 @@ interface SearchContentProps {
 const SearchContent: React.FC<SearchContentProps> = ({ songs }) => {
   if (songs.length === 0) {
     return (
-      <div className="flex flex-col w-full px-6 gap-y-2 text-neutral-400">
+      <div className="flex flex-col w-full px-6 text-center gap-y-2 text-neutral-400">
         No songs found!
       </div>
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import ToasterProvider from '~/providers/ToasterProvider';
 import UserProvider from '~/providers/UserProvider';
 import getActiveProductsWithPrices from '~/server/actions/getActiveProductsWithPrices';
 import getSongsByUserId from '~/server/actions/getSongsByUserId';
+import { NavigationFeature } from '~/features/navigation/navigation';
 
 const font = Figtree({ subsets: ['latin'] });
 
@@ -73,7 +74,10 @@ export default async function RootLayout({ children }: PropsWithChildren) {
           <UserProvider>
             <ModalProvider products={products} />
             <Sidebar songs={userSongs}>{children}</Sidebar>
-            <PlayerFeature />
+            <div className="fixed bottom-0 w-full">
+              <PlayerFeature />
+              <NavigationFeature/>
+            </div>
           </UserProvider>
         </SupabaseProvider>
       </body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,65 +23,35 @@ const Header: React.FC<HeaderProps> = ({ children, className }) => {
   const authModal = useAuthModal();
   const router = useRouter();
 
-  const supabaseClient = useSupabaseClient();
   const { user } = useUser();
-
-  const handleLogout = async () => {
-    const { error } = await supabaseClient.auth.signOut();
-    // TODO: reset any playing songs
-    router.refresh();
-
-    if (error) {
-      toast.error(error.message);
-    } else {
-      toast.success('Logged out successfully');
-    }
-  };
 
   return (
     <div
       className={twMerge(`h-fit bg-gradient-to-b from-blue-800 p-6`, className)}
     >
-      <div className="flex items-center justify-between w-full mb-4">
+      <div className="flex items-center justify-between w-full mb-4 max-md:justify-end">
         <div className="items-center hidden md:flex gap-x-2">
           <button
             onClick={() => router.back()}
-            className="flex items-center justify-center transition bg-black rounded-full hover:opacity-75"
+            className="rounded-full transition-colors duration-200 hover:bg-black/20"
           >
             <RxCaretLeft className="text-white" size={35} />
           </button>
           <button
             onClick={() => router.forward()}
-            className="flex items-center justify-center transition bg-black rounded-full hover:opacity-75"
+            className="rounded-full transition-colors duration-200 hover:bg-black/20"
           >
             <RxCaretRight className="text-white" size={35} />
           </button>
         </div>
-        <div className="flex items-center md:hidden gap-x-2">
-          <Link href="/">
-            <button className="flex items-center justify-center p-2 transition bg-white rounded-full hover:opacity-75">
-              <HiHome className="text-black" size={20} />
-            </button>
-          </Link>
-          <Link href="/search">
-            <button className="flex items-center justify-center p-2 transition bg-white rounded-full hover:opacity-75">
-              <BiSearch className="text-black" size={20} />
-            </button>
-          </Link>
-        </div>
-        <div className="flex items-center justify-between gap-x-4">
+        <div className="flex items-center justify-between gap-x-2">
           {user ? (
-            <div className="flex items-center gap-x-4">
-              <Button onClick={handleLogout} className="px-6 py-2 bg-white">
-                Logout
-              </Button>
-              <Button
-                onClick={() => router.push('/account')}
-                className="bg-white"
-              >
-                <FaUserAlt />
-              </Button>
-            </div>
+            <button
+              onClick={() => router.push('/account')}
+              className="w-[35px] h-[35px] max-md:hidden flex items-center justify-center rounded-full transition-colors duration-200 hover:bg-black/20"
+            >
+              <FaUserAlt className="text-white" size={15}/>
+            </button>
           ) : (
             <>
               <div>

--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -9,6 +9,7 @@ const PlayButton = () => {
         rounded-full
         flex
         items-center
+        justify-center
         bg-blue-400
         p-4
         drop-shadow-md

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,10 +38,11 @@ const Sidebar: React.FC<SidebarProps> = ({ children, songs }) => {
     ],
     [pathname],
   );
+
   return (
     <div
       className={twMerge(
-        `*:
+        `
         flex
         h-screen
         overflow-hidden
@@ -62,8 +63,8 @@ const Sidebar: React.FC<SidebarProps> = ({ children, songs }) => {
       </div>
       <main
         className={cn(
-          'flex-1 h-full py-2 overflow-y-auto',
-          currentSong ? 'h-[calc(100%-64px)]' : 'h-full',
+          'flex-1 pt-2 overflow-auto',
+          currentSong ? "pb-[160px] md:pb-[80px]" : "pb-[80px] md:pb-0"
         )}
       >
         {children}

--- a/src/features/navigation/navigation.tsx
+++ b/src/features/navigation/navigation.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import useAuthModal from '~/hooks/useAuthModal';
+import { useRouter } from 'next/navigation';
+import { useUser } from '~/hooks/useUser';
+import Link from 'next/link';
+import { BiSearch } from 'react-icons/bi';
+import { FaUser } from 'react-icons/fa';
+import { User } from '@supabase/auth-helpers-nextjs';
+import { GoHomeFill } from 'react-icons/go';
+
+export function NavigationFeature() {
+  const { user } = useUser();
+
+  return (
+    <div className="md:hidden flex justify-around align-middle h-[80px] pb-[env(safe-area-inset-bottom)]">
+      <Link className="pt-3" href="/">
+        <GoHomeFill size={40}/>
+      </Link>
+      <Link className="pt-3" href="/search">
+        <BiSearch size={40} />
+      </Link>
+      <Profile user={user}/>
+    </div>
+  );
+}
+
+interface ProfileProps {
+  user: User | null;
+}
+
+function Profile({ user }: ProfileProps) {
+  const router = useRouter();
+  const authModal = useAuthModal();
+
+  const handleClick = () => {
+    if (user) {
+      router.push("/account");
+    } else {
+      authModal.onOpen();
+    }
+  };
+
+  return (
+    <button
+      className="h-0 pt-3"
+      onClick={handleClick}
+    >
+      <FaUser size={35} />
+    </button>
+  )
+}

--- a/src/features/player/components/player-details.tsx
+++ b/src/features/player/components/player-details.tsx
@@ -18,7 +18,7 @@ export function PlayerDetails() {
     <div className="flex justify-start w-full">
       <div className="flex items-center gap-x-4">
         {/* Media item */}
-        <div className="flex items-center w-full p-2 rounded-md cursor-pointer gap-x-3 hover:bg-neutral-800/50">
+        <div className="flex items-center w-full p-2 rounded-md cursor-pointer gap-x-3 hover:bg-neutral-800/50 max-md:max-w-72 max-w-96">
           <div className="relative overflow-hidden rounded-md min-h-12 min-w-12">
             <Image
               fill

--- a/src/features/player/player.tsx
+++ b/src/features/player/player.tsx
@@ -62,7 +62,7 @@ export function PlayerFeature() {
   if (!currentSong) return null;
 
   return (
-    <div className="fixed bottom-0 w-full h-20 bg-black">
+    <div className="w-full h-20 max-md:from-blue-950 max-md:bg-gradient-to-b ">
       <SeekSlider />
       <div className="px-4 py-2">
         <div className="grid h-full grid-cols-2 md:grid-cols-3">


### PR DESCRIPTION
This PR includes various styling changes including moving the navigation to the bottom in mobile.

Album aspect ratio respected:
<img width="860" alt="Screen Shot 2025-02-10 at 5 20 37 PM" src="https://github.com/user-attachments/assets/009c94db-745f-42bc-a579-bc366363e7c8" />

New back/forward buttons (forward button hovered):
<img width="171" alt="Screen Shot 2025-02-10 at 5 20 42 PM" src="https://github.com/user-attachments/assets/5e4336dc-93be-4840-95c9-c37e87f01c03" />

Centered empty state text:
<img width="322" alt="Screen Shot 2025-02-10 at 5 21 27 PM" src="https://github.com/user-attachments/assets/a96c2f0c-a6cb-4ce2-8704-196d9e8bc8d0" />

Album meta data stacked in mobile:
<img width="315" alt="Screen Shot 2025-02-10 at 5 22 04 PM" src="https://github.com/user-attachments/assets/e664bd18-ef64-4e1b-9cc4-b64ba9554f92" />

New bottom nav with truncated text:
<img width="318" alt="Screen Shot 2025-02-10 at 5 25 07 PM" src="https://github.com/user-attachments/assets/951789e7-fa6a-4179-9ab3-27658cf246ab" />

Logout moved to account page:
<img width="313" alt="Screen Shot 2025-02-10 at 5 41 59 PM" src="https://github.com/user-attachments/assets/450bc517-4f59-4db4-b66b-97392645a0b5" />